### PR TITLE
add stream_info for `DecoderWrapper` and `EncoderWrapper`

### DIFF
--- a/examples/encoding.rs
+++ b/examples/encoding.rs
@@ -19,15 +19,15 @@ fn main() -> anyhow::Result<()> {
 
     rsmedia::init().unwrap();
 
+    let width = 640;
+    let height = 640;
+    
     let filters = vec![
-        filter::video::scale(1920, 1080, Some("bicubic")),
-        filter::video::crop(100, 100, 1600, 900),
-        filter::video::drawtext("Watermark", 50, 50, "fonts/Arial.ttf", 24, "white@0.5"),
-        filter::video::hflip(),
+        filter::video::scale(1280, 720, Some("bicubic")),
+        filter::video::crop(20, 20, width, height),
+        filter::video::drawtext("Watermark", 50, 50, "fonts/Arial.ttf", 18, "white@0.5"),
     ];
-
-    let width = 1280;
-    let height = 720;
+ 
     let output_path = Path::new("/tmp/rainbow.mp4");
 
     let mut encoder = EncoderBuilder::new_video(width as usize, height as usize)

--- a/examples/encoding.rs
+++ b/examples/encoding.rs
@@ -21,13 +21,13 @@ fn main() -> anyhow::Result<()> {
 
     let width = 640;
     let height = 640;
-    
+
     let filters = vec![
         filter::video::scale(1280, 720, Some("bicubic")),
         filter::video::crop(20, 20, width, height),
         filter::video::drawtext("Watermark", 50, 50, "fonts/Arial.ttf", 18, "white@0.5"),
     ];
- 
+
     let output_path = Path::new("/tmp/rainbow.mp4");
 
     let mut encoder = EncoderBuilder::new_video(width as usize, height as usize)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -809,12 +809,18 @@ unsafe impl Sync for Decoder {}
 pub struct DecoderWrapper<R: Reader> {
     reader: R,
     decoder: Decoder,
+    stream_info: StreamInfo,
 }
 
 impl<R: Reader> DecoderWrapper<R> {
     /// 创建一个新的解码器包装器
     pub fn new(decoder: Decoder, reader: R) -> Self {
-        Self { decoder, reader }
+        let stream_info = StreamInfo::from_reader(&reader, decoder.stream_index()).unwrap();
+        Self {
+            reader,
+            decoder,
+            stream_info,
+        }
     }
 
     /// 解码下一帧（媒体帧）
@@ -826,6 +832,10 @@ impl<R: Reader> DecoderWrapper<R> {
     /// 解码下一帧（原始帧）
     pub fn decode_raw(&mut self) -> Result<Option<AVFrame>> {
         self.decoder.decode_raw(&mut self.reader)
+    }
+
+    pub fn stream_info(&self) -> &StreamInfo {
+        &self.stream_info
     }
 
     /// 获取内部解码器的可变引用

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -7,6 +7,7 @@ use crate::hwaccel::{HWContext, HWDeviceConfig};
 use crate::io::Writer;
 use crate::options::Options;
 use crate::pixel::PixelFormat;
+use crate::stream::StreamInfo;
 use crate::{swctx, time, utils, Location, MediaType, SampleFormat, StreamWriter};
 
 use rsmpeg::avcodec::{AVCodec, AVCodecContext, AVCodecParameters, AVPacket};
@@ -941,6 +942,7 @@ pub struct EncoderWrapper<W: Writer> {
     encoder: Encoder,
     interleaved: bool,
     stream_index: usize,
+    stream_info: StreamInfo,
     have_written_header: bool,
     have_written_trailer: bool,
 }
@@ -948,11 +950,13 @@ pub struct EncoderWrapper<W: Writer> {
 impl<W: Writer> EncoderWrapper<W> {
     /// 创建一个新的编码器包装器
     pub fn new(encoder: Encoder, writer: W, stream_index: usize, interleaved: bool) -> Self {
+        let stream_info = StreamInfo::from_writer(&writer, stream_index).unwrap();
         Self {
             writer,
             encoder,
             interleaved,
             stream_index,
+            stream_info,
             have_written_header: false,
             have_written_trailer: false,
         }
@@ -971,11 +975,15 @@ impl<W: Writer> EncoderWrapper<W> {
             self.have_written_header = true;
         }
 
-        if let Some(mut pkt) = self.encoder.encode_raw(frame)? {
+        if let Some(mut packet) = self.encoder.encode_raw(frame)? {
+            packet.set_pos(-1);
+            packet.set_stream_index(self.stream_index as i32);
+            packet.rescale_ts(self.time_base(), self.stream_info.time_base);
+
             if self.interleaved {
-                self.writer.write_interleaved(&mut pkt)?;
+                self.writer.write_interleaved(&mut packet)?;
             } else {
-                self.writer.write_frame(&mut pkt)?;
+                self.writer.write_frame(&mut packet)?;
             }
         }
 
@@ -1004,12 +1012,16 @@ impl<W: Writer> EncoderWrapper<W> {
             &mut self.writer,
             self.interleaved,
             self.stream_index,
-            self.encoder.time_base(),
+            self.stream_info.time_base,
         )
     }
 
     pub fn time_base(&self) -> ffi::AVRational {
         self.encoder.time_base()
+    }
+
+    pub fn stream_info(&self) -> &StreamInfo {
+        &self.stream_info
     }
 
     /// 获取内部编码器的可变引用

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -650,11 +650,7 @@ impl Encoder {
                 } else {
                     self.pix_fmt()
                 };
-
-                if frame.width != self.width()
-                    || frame.height != self.height()
-                    || frame.format != target_sw_pix_fmt.into()
-                {
+                if frame.format != target_sw_pix_fmt.into() {
                     swctx::scale(&frame, self.width(), self.height(), target_sw_pix_fmt)?
                 } else {
                     frame

--- a/src/hwaccel.rs
+++ b/src/hwaccel.rs
@@ -395,9 +395,6 @@ impl HWContext {
 
     /// 复制帧属性
     ///
-    /// This method copies essential properties and side data from the source frame to the destination frame.
-    /// It uses manual copying instead of `ffi::av_frame_copy_props` due to runtime errors encountered with the latter.
-    ///
     /// # Arguments
     /// * `dst` - The destination frame to which properties will be copied.
     /// * `src` - The source frame from which properties will be copied.
@@ -425,7 +422,7 @@ impl HWContext {
             }
         }
 
-        // 注意：这里尝试使用 av_frame_copy_props 会导致 runtime error:
+        // 注意：这里尝试使用 ffi 拷贝属性会导致 runtime error:
         // unsafe {
         //     ffi::av_frame_copy_props(sw_frame.as_mut_ptr(), hw_frame.as_ptr());
         // }

--- a/src/hwaccel.rs
+++ b/src/hwaccel.rs
@@ -1,5 +1,5 @@
 use crate::pixel::PixelFormat;
-use crate::{utils, Options};
+use crate::{imgutils, utils, Options};
 
 use rsmpeg::avcodec::{AVCodec, AVCodecContext};
 use rsmpeg::avutil::{AVFrame, AVHWDeviceContext, AVHWFramesContext};
@@ -310,7 +310,7 @@ impl HWContext {
             .context("Failed to transfer data from hardware frame to software frame")?;
 
         // 复制帧属性
-        self.copy_frame_props(&mut sw_frame, hw_frame);
+        self.copy_frame_props(hw_frame, &mut sw_frame)?;
 
         log::debug!(
             "Downloaded from GPU: format={:?}, size={}x{}, linesize=[{}, {}], cost={:?}ms",
@@ -378,7 +378,7 @@ impl HWContext {
             .context("Failed to transfer data from software frame to hardware frame")?;
 
         // 复制帧属性
-        self.copy_frame_props(&mut hw_frame, sw_frame);
+        self.copy_frame_props(sw_frame, &mut hw_frame)?;
 
         log::debug!(
             "Uploaded to GPU: format={:?}, size={}x{}, linesize=[{}, {}], cost={:?}ms",
@@ -398,7 +398,7 @@ impl HWContext {
     /// # Arguments
     /// * `dst` - The destination frame to which properties will be copied.
     /// * `src` - The source frame from which properties will be copied.
-    fn copy_frame_props(&self, dst: &mut AVFrame, src: &AVFrame) {
+    fn copy_frame_props(&self, src: &AVFrame, dst: &mut AVFrame) -> Result<()> {
         dst.set_pts(src.pts);
         dst.set_time_base(src.time_base);
         dst.set_pict_type(src.pict_type);
@@ -408,24 +408,15 @@ impl HWContext {
 
         unsafe {
             let dst_ptr = dst.as_mut_ptr();
+            (*dst_ptr).flags = src.flags;
+            (*dst_ptr).opaque = src.opaque;
             (*dst_ptr).quality = src.quality;
+            (*dst_ptr).duration = src.duration;
             (*dst_ptr).sample_aspect_ratio = src.sample_aspect_ratio;
-
-            // copy side_data
-            for i in 0..src.nb_side_data {
-                let side_data = *src.side_data.add(i as usize);
-                ffi::av_frame_new_side_data_from_buf(
-                    dst_ptr,
-                    (*side_data).type_,
-                    ffi::av_buffer_ref((*side_data).buf),
-                );
-            }
         }
 
-        // 注意：这里尝试使用 ffi 拷贝属性会导致 runtime error:
-        // unsafe {
-        //     ffi::av_frame_copy_props(sw_frame.as_mut_ptr(), hw_frame.as_ptr());
-        // }
+        // 复制帧属性
+        imgutils::copy_frame_metadata(src, dst, false)
     }
 
     /// Determine if a frame is in hardware memory

--- a/src/imgutils.rs
+++ b/src/imgutils.rs
@@ -147,8 +147,14 @@ pub fn copy_frame_to_buffer(frame: &AVFrame) -> Result<Vec<u8>> {
     }
 }
 
-/// 完整复制 AVFrame（包括数据和属性）
-pub fn copy_frame_props(src: &AVFrame, dst: &mut AVFrame, copy_data: bool) -> Result<()> {
+/// 完整复制 AVFrame
+///
+/// # Arguments
+///
+/// * `src` - 源 AVFrame
+/// * `dst` - 目标 AVFrame
+/// * `copy_data` - 是否复制数据
+pub fn copy_frame_metadata(src: &AVFrame, dst: &mut AVFrame, copy_data: bool) -> Result<()> {
     unsafe {
         if copy_data {
             // 目标 AVFrame 需已分配内存
@@ -161,7 +167,7 @@ pub fn copy_frame_props(src: &AVFrame, dst: &mut AVFrame, copy_data: bool) -> Re
             }
         }
 
-        // 复制属性
+        // 复制属性：仅包含 metadata 和 side_data
         let ret = ffi::av_frame_copy_props(dst.as_mut_ptr(), src.as_ptr());
         if ret < 0 {
             return Err(anyhow::anyhow!("Failed to copy frame properties: {}", ret));
@@ -926,7 +932,7 @@ mod tests {
         );
 
         // 测试复制
-        copy_frame_props(&src_frame, &mut dst_frame, true)?;
+        copy_frame_metadata(&src_frame, &mut dst_frame, true)?;
 
         // 验证目标frame属性
         assert_eq!(dst_frame.width, 320, "Frame width mismatch");

--- a/src/imgutils.rs
+++ b/src/imgutils.rs
@@ -148,15 +148,17 @@ pub fn copy_frame_to_buffer(frame: &AVFrame) -> Result<Vec<u8>> {
 }
 
 /// 完整复制 AVFrame（包括数据和属性）
-pub fn copy_frame(src: &AVFrame, dst: &mut AVFrame) -> Result<()> {
-    // 目标 AVFrame 需已分配内存
-    assert!(dst.is_allocated(), "destination frame is not allocated");
-
+pub fn copy_frame_props(src: &AVFrame, dst: &mut AVFrame, copy_data: bool) -> Result<()> {
     unsafe {
-        // 复制数据
-        let ret = ffi::av_frame_copy(dst.as_mut_ptr(), src.as_ptr());
-        if ret < 0 {
-            return Err(anyhow::anyhow!("Failed to copy frame data: {}", ret));
+        if copy_data {
+            // 目标 AVFrame 需已分配内存
+            assert!(dst.is_allocated(), "destination frame is not allocated");
+
+            // 复制数据
+            let ret = ffi::av_frame_copy(dst.as_mut_ptr(), src.as_ptr());
+            if ret < 0 {
+                return Err(anyhow::anyhow!("Failed to copy frame data: {}", ret));
+            }
         }
 
         // 复制属性
@@ -924,7 +926,7 @@ mod tests {
         );
 
         // 测试复制
-        copy_frame(&src_frame, &mut dst_frame)?;
+        copy_frame_props(&src_frame, &mut dst_frame, true)?;
 
         // 验证目标frame属性
         assert_eq!(dst_frame.width, 320, "Frame width mismatch");

--- a/src/swctx.rs
+++ b/src/swctx.rs
@@ -1,4 +1,4 @@
-use crate::{time, PixelFormat, SampleFormat};
+use crate::{imgutils, time, PixelFormat, SampleFormat};
 
 use rsmpeg::avutil::{AVFrame, AVSamples};
 use rsmpeg::ffi;
@@ -121,15 +121,10 @@ pub fn scale(
     dst_frame.set_width(dst_width);
     dst_frame.set_height(dst_height);
     dst_frame.set_format(dst_pix_fmt.into());
-    // copy props
-    let ret = unsafe { ffi::av_frame_copy_props(dst_frame.as_mut_ptr(), src_frame.as_ptr()) };
-    if ret < 0 {
-        return Err(Error::msg(format!("Failed to copy props, ret: {}", ret)));
-    }
-
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
+    imgutils::copy_frame(src_frame, &mut dst_frame)?;
 
     let mut sws_ctx = setup_scaler(
         src_frame.width,
@@ -142,11 +137,22 @@ pub fn scale(
     .context("Failed to create swscale context.")?;
 
     let ret = unsafe {
-        ffi::sws_scale_frame(
-            sws_ctx.as_mut_ptr(),
-            dst_frame.as_mut_ptr(),
-            src_frame.as_ptr(),
-        )
+        let dst_frame_ptr = dst_frame.as_mut_ptr();
+        // set color properties:
+        // 指定像素分量值（Y, U, V 或 R, G, B）的范围
+        // - AVCOL_RANGE_MPEG (或 AVCOL_RANGE_LIMITED): 有限范围，通常用于广播电视标准（如 BT.709），Y 值范围通常是 16-235，UV 值范围是 16-240
+        // - AVCOL_RANGE_JPEG (或 AVCOL_RANGE_FULL): 全范围，通常用于计算机图形和数字摄影，YUV 或 RGB 值范围通常是 0-255
+        (*dst_frame_ptr).color_range = ffi::AVCOL_RANGE_JPEG;
+        // 表示的颜色范围, 决定了图像的色域
+        (*dst_frame_ptr).color_primaries = ffi::AVCOL_PRI_RESERVED0;
+        // 伽马校正（Gamma）:描述了编码的像素值（数字信号）和实际场景光线强度之间的非线性关系
+        (*dst_frame_ptr).color_trc = ffi::AVCOL_TRC_RESERVED0;
+        // 转换矩阵系数: 与 color_primaries 紧密相关，因为转换矩阵通常依赖于原色定义
+        (*dst_frame_ptr).colorspace = ffi::AVCOL_SPC_RGB;
+        // 指定色度样本（U, V）相对于亮度样本（Y）的采样位置, 不做要求
+        (*dst_frame_ptr).chroma_location = ffi::AVCHROMA_LOC_UNSPECIFIED;
+
+        ffi::sws_scale_frame(sws_ctx.as_mut_ptr(), dst_frame_ptr, src_frame.as_ptr())
     };
     if ret < 0 {
         return Err(Error::msg(format!("Failed to scale frame, ret: {}", ret)));
@@ -180,15 +186,10 @@ pub fn scale_frame(
     dst_frame.set_width(dst_width);
     dst_frame.set_height(dst_height);
     dst_frame.set_format(dst_pix_fmt.into());
-    // copy props
-    let ret = unsafe { ffi::av_frame_copy_props(dst_frame.as_mut_ptr(), src_frame.as_ptr()) };
-    if ret < 0 {
-        return Err(Error::msg(format!("Failed to copy props, ret: {}", ret)));
-    }
-
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
+    imgutils::copy_frame(src_frame, &mut dst_frame)?;
 
     let mut sws_ctx = setup_scaler(
         src_frame.width,
@@ -342,6 +343,7 @@ pub fn convert_frame(
     .context("Failed to create resample context.")?;
 
     let mut dst_frame = AVFrame::new();
+    // copy properties
     let ret = unsafe { ffi::av_frame_copy_props(dst_frame.as_mut_ptr(), src_frame.as_ptr()) };
     if ret < 0 {
         return Err(Error::msg(format!("Failed to copy props, ret: {}", ret)));

--- a/src/swctx.rs
+++ b/src/swctx.rs
@@ -124,7 +124,7 @@ pub fn scale(
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
-    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
+    imgutils::copy_frame_metadata(src_frame, &mut dst_frame, false)?;
     let mut sws_ctx = setup_scaler(
         src_frame.width,
         src_frame.height,
@@ -188,7 +188,7 @@ pub fn scale_frame(
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
-    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
+    imgutils::copy_frame_metadata(src_frame, &mut dst_frame, false)?;
 
     let mut sws_ctx = setup_scaler(
         src_frame.width,
@@ -343,7 +343,7 @@ pub fn convert_frame(
 
     let mut dst_frame = AVFrame::new();
     // copy props
-    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
+    imgutils::copy_frame_metadata(src_frame, &mut dst_frame, false)?;
     dst_frame.set_format(out_sample_fmt);
     dst_frame.set_ch_layout(out_ch_layout);
     dst_frame.set_nb_samples(src_frame.nb_samples);

--- a/src/swctx.rs
+++ b/src/swctx.rs
@@ -342,12 +342,8 @@ pub fn convert_frame(
     .context("Failed to create resample context.")?;
 
     let mut dst_frame = AVFrame::new();
-    // copy properties
-    let ret = unsafe { ffi::av_frame_copy_props(dst_frame.as_mut_ptr(), src_frame.as_ptr()) };
-    if ret < 0 {
-        return Err(Error::msg(format!("Failed to copy props, ret: {}", ret)));
-    }
-
+    // copy props
+    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
     dst_frame.set_format(out_sample_fmt);
     dst_frame.set_ch_layout(out_ch_layout);
     dst_frame.set_nb_samples(src_frame.nb_samples);

--- a/src/swctx.rs
+++ b/src/swctx.rs
@@ -124,8 +124,7 @@ pub fn scale(
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
-    imgutils::copy_frame(src_frame, &mut dst_frame)?;
-
+    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
     let mut sws_ctx = setup_scaler(
         src_frame.width,
         src_frame.height,
@@ -189,7 +188,7 @@ pub fn scale_frame(
     dst_frame
         .alloc_buffer()
         .context("Failed to allocate destination frame buffer")?;
-    imgutils::copy_frame(src_frame, &mut dst_frame)?;
+    imgutils::copy_frame_props(src_frame, &mut dst_frame, false)?;
 
     let mut sws_ctx = setup_scaler(
         src_frame.width,


### PR DESCRIPTION
1. add stream_info for `DecoderWrapper` and `EncoderWrapper`
2. update `EncoderWrapper` encode `rescale_ts` from stream_info 
3. support `swctx::scale` output frame color properties: e.g. for deprecated YUVJ420P, need `colorspace` and 'color_range' to full color conversion